### PR TITLE
Remove amp keyword

### DIFF
--- a/packages/twentynineteen-theme/package.json
+++ b/packages/twentynineteen-theme/package.json
@@ -6,9 +6,8 @@
   "keywords": [
     "frontity",
     "frontity-theme",
-    "frontity-amp",
-	"twentynineteen",
-	"twentynineteen-theme"
+    "twentynineteen",
+    "twentynineteen-theme"
   ],
   "homepage": "https://frontity.org",
   "license": "MIT",


### PR DESCRIPTION
Sorry about that, it is wrong in Mars Theme as well. It shouldn't be there until these theme support AMP. We need to release the `@frontity/amp` package first.