### PR TITLE
Add aria-label to navigation links to improve mobile accesibility

### DIFF
--- a/packages/twentynineteen-theme/src/components/link.js
+++ b/packages/twentynineteen-theme/src/components/link.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { connect, styled } from "frontity";
 
-const Link = ( { actions, link, className, children } ) => {
+const Link = ( { actions, link, className, ariaLabel, children } ) => {
   const onClick = event => {
     // Do nothing if it's an external link
     if ( link.startsWith( "http" ) ) return;
@@ -13,7 +13,7 @@ const Link = ( { actions, link, className, children } ) => {
   };
 
   return (
-    <LinkEl href={ link } onClick={ onClick } className={ className }>
+    <LinkEl href={ link } onClick={ onClick } className={ className } aria-label={ ariaLabel }>
       { children }
     </LinkEl>
   );

--- a/packages/twentynineteen-theme/src/components/list/pagination.js
+++ b/packages/twentynineteen-theme/src/components/list/pagination.js
@@ -116,7 +116,7 @@ const Pagination = ( { state, actions, libraries } ) => {
 	return (
 		<PaginationContainer className="tn-pagination">
 			{ isTherePreviousPage && (
-				<Link className="pagination-links prev" link={ getPageLink( page - 1 ) }>
+				<Link className="pagination-links prev" ariaLabel="Read newer posts" link={ getPageLink( page - 1 ) }>
 					<PreviousIcon />
 					<span className="nav-prev-text">Newer posts</span>
 				</Link>
@@ -145,7 +145,7 @@ const Pagination = ( { state, actions, libraries } ) => {
 			</>
 
 			{ isThereNextPage && (
-				<Link className="pagination-links next" link={ getPageLink( page + 1 ) }>
+				<Link className="pagination-links next" ariaLabel="Read older posts" link={ getPageLink( page + 1 ) }>
 					<span className="nav-next-text">Older posts</span>
 					<NextIcon />
 				</Link>


### PR DESCRIPTION
At this moment, LightHouse audit is reporting that the navigation links "do not have a discernible name". It is solved just by adding the tag `aria-label` with a description of the link.