### PR TITLE
Fix loader not visible for mobile #20

### DIFF
--- a/packages/twentynineteen-theme/src/components/loading.js
+++ b/packages/twentynineteen-theme/src/components/loading.js
@@ -17,7 +17,7 @@ const Loading = () => (
 export default Loading;
 
 const Container = styled.div`
-  width: 800px;
+  width: 100%;
   margin: 0;
   padding: 24px;
   display: flex;


### PR DESCRIPTION
Change Loader container's width to 100%